### PR TITLE
Feature/amend date range add most recent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    swab (2.0.0)
+    swab (2.1.0)
       mechanize (~> 2.7)
       slop (~> 4.0)
       tty-spinner (~> 0.9)
@@ -10,7 +10,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.2)
-    connection_pool (2.2.2)
+    connection_pool (2.2.3)
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -26,14 +26,14 @@ GEM
       ntlm-http (~> 0.1, >= 0.1.1)
       webrobots (>= 0.0.9, < 0.2)
     method_source (0.9.2)
-    mime-types (3.2.2)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2020.1104)
     mini_portile2 (2.4.0)
     net-http-digest_auth (1.4.1)
-    net-http-persistent (3.1.0)
+    net-http-persistent (4.0.0)
       connection_pool (~> 2.2)
-    nokogiri (1.10.4)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     ntlm-http (0.1.1)
     pry (0.12.2)
@@ -53,13 +53,13 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
-    slop (4.7.0)
-    tty-cursor (0.7.0)
-    tty-spinner (0.9.1)
+    slop (4.8.2)
+    tty-cursor (0.7.1)
+    tty-spinner (0.9.3)
       tty-cursor (~> 0.7)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.7.7)
     webrobots (0.1.2)
 
 PLATFORMS
@@ -74,4 +74,4 @@ DEPENDENCIES
   swab!
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/exe/swab
+++ b/exe/swab
@@ -13,7 +13,7 @@ opts = Slop.parse do |o|
   o.string '-u', '--user', 'username', required: true
   o.string '-p', '--pass', 'password', required: true
   o.string '-o', '--out', 'destination', default: 'out.csv'
-  o.integer '-m', '--months', 'Number of months', default: 3
+  o.integer '-m', '--months', 'Number of months', default: 1
   o.bool '-r', '--recent', 'Most Recently updated shifts', default: false
   o.separator ''
   o.separator 'Other options'

--- a/exe/swab
+++ b/exe/swab
@@ -8,12 +8,13 @@ require 'swab'
 ARGV << '-h' if ARGV.empty?
 opts = nil
 
-opts = Slop.parse do |o|  
+opts = Slop.parse do |o|
   o.string '-l', '--url', 'URL', required: true
   o.string '-u', '--user', 'username', required: true
   o.string '-p', '--pass', 'password', required: true
   o.string '-o', '--out', 'destination', default: 'out.csv'
   o.integer '-m', '--months', 'Number of months', default: 3
+  o.bool '-r', '--recent', 'Most Recently updated shifts', default: false
   o.separator ''
   o.separator 'Other options'
   o.on '-v', 'version' do
@@ -30,8 +31,8 @@ spinner = TTY::Spinner.new('[:spinner] :title ... ', format: :classic)
 spinner.update(title: 'Starting up')
 spinner.auto_spin
 
-data = Swab.swab(opts[:url], opts[:user], opts[:pass], opts[:months], spinner)
-CSV.open( opts[:out], 'wb' ) do |csv|
+data = Swab.swab(opts[:url], opts[:user], opts[:pass], opts[:months], opts[:recent], spinner)
+CSV.open( opts[:out], 'wb') do |csv|
   data.each { |row| csv << row }
 end
 

--- a/lib/swab.rb
+++ b/lib/swab.rb
@@ -6,14 +6,20 @@ module Swab
   class Error < StandardError; end
   
   
-  def self.swab(url, user, pass, months, spinner)
+  def self.swab(url, user, pass, months, recent, spinner)
     parser = Parser.new(url)
     
     spinner.update(title: 'Logging in' ) if spinner
     parser.login(user, pass )
-    
-    spinner.update(title: 'Setting date range' ) if spinner
-    parser.set_date_range(months)
+
+    if recent
+      spinner.update(title: 'Setting most recent checkbox' ) if spinner
+      parser.set_most_recent
+    else
+      spinner.update(title: 'Setting date range' ) if spinner
+      parser.set_date_range(months)
+    end
+
     
     spinner.update(title: 'Scraping' ) if spinner
     data = parser.parse { |page| spinner.update(title: "Scaping page #{page+1}") }

--- a/lib/swab/parser.rb
+++ b/lib/swab/parser.rb
@@ -22,8 +22,8 @@ module Swab
     end
     
     def set_date_range(months)
-      start_date = Date.today
-      end_date = start_date >> months
+      start_date = months == 1 ? Date.today : Date.today >> months
+      end_date = start_date >> 1
       
       form = @page.form_with(name: 'aspnetForm')
       form.add_field!('ctl00$ToolkitScriptManager1', 'ctl00$content$BookingStatusUpdatePanel|ctl00$content$BookingStatus1$cmdSubmitPrint')
@@ -33,6 +33,14 @@ module Swab
       form['ctl00$content$BookingStatus1$mListDateOptions'] = 'DateRange'
       form['ctl00$content$BookingStatus1$StartDate'] = start_date.strftime '%d-%b-%y'
       form['ctl00$content$BookingStatus1$EndDate'] = end_date.strftime '%d-%b-%y'
+      @page = form.submit
+    end
+
+    def set_most_recent
+      form = @page.form_with(name: 'aspnetForm')
+      form.add_field!('ctl00$ToolkitScriptManager1', 'ctl00$content$BookingStatusUpdatePanel|ctl00$content$BookingStatus1$cmdSubmitPrint')
+      form.add_field!('ctl00$content$BookingStatus1$cmdSubmitPrint', 'Filter')
+      form.checkbox_with(id: 'ctl00_content_BookingStatus1_chkIsRecentlyAdded').check
       @page = form.submit
     end
     

--- a/lib/swab/parser.rb
+++ b/lib/swab/parser.rb
@@ -22,7 +22,7 @@ module Swab
     end
     
     def set_date_range(months)
-      start_date = months == 1 ? Date.today : Date.today >> months
+      start_date = months == 1 ? Date.today : Date.today >> (months - 1)
       end_date = start_date >> 1
       
       form = @page.form_with(name: 'aspnetForm')

--- a/lib/swab/version.rb
+++ b/lib/swab/version.rb
@@ -1,3 +1,3 @@
 module Swab
-  VERSION = "2.0.0"
+  VERSION = '2.1.0'.freeze
 end


### PR DESCRIPTION
Due to the number of results coming back from a date range it was suggested that we try and restrict the number of results coming through. 

e.g 
- m1 = Will as before return a month in advance (today -> 1 month in future)
- m2 = (start date = (today + 1 month)) -> (start date + 1 month in future)
- m3 = (start date = (today + 2 months)) -> (start date + 1 month in future)
...

Also added the functionality to set the checkbox for the most recently updated in the last 24hrs.