### PR TITLE
Bugfix/most recent checkbox can enter dates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    swab (2.1.0)
+    swab (2.1.1)
       mechanize (~> 2.7)
       slop (~> 4.0)
       tty-spinner (~> 0.9)

--- a/lib/swab.rb
+++ b/lib/swab.rb
@@ -4,25 +4,22 @@ require "swab/version"
 
 module Swab
   class Error < StandardError; end
-  
-  
+
   def self.swab(url, user, pass, months, recent, spinner)
     parser = Parser.new(url)
-    
-    spinner.update(title: 'Logging in' ) if spinner
-    parser.login(user, pass )
+
+    spinner.update(title: 'Logging in') if spinner
+    parser.login(user, pass)
 
     if recent
-      spinner.update(title: 'Setting most recent checkbox' ) if spinner
+      spinner.update(title: 'Setting most recent checkbox') if spinner
       parser.set_most_recent
-    else
-      spinner.update(title: 'Setting date range' ) if spinner
-      parser.set_date_range(months)
     end
+    spinner.update(title: 'Setting date range') if spinner
+    parser.set_date_range(months)
 
-    
-    spinner.update(title: 'Scraping' ) if spinner
-    data = parser.parse { |page| spinner.update(title: "Scaping page #{page+1}") }
-#     puts data
+    spinner.update(title: 'Scraping') if spinner
+    data = parser.parse { |page| spinner.update(title: "Scaping page #{page + 1}") }
+    #     puts data
   end
 end

--- a/lib/swab/parser.rb
+++ b/lib/swab/parser.rb
@@ -41,7 +41,6 @@ module Swab
       form.add_field!('ctl00$ToolkitScriptManager1', 'ctl00$content$BookingStatusUpdatePanel|ctl00$content$BookingStatus1$cmdSubmitPrint')
       form.add_field!('ctl00$content$BookingStatus1$cmdSubmitPrint', 'Filter')
       form.checkbox_with(id: 'ctl00_content_BookingStatus1_chkIsRecentlyAdded').check
-      @page = form.submit
     end
     
     def parse(data = [], count = 0)

--- a/lib/swab/version.rb
+++ b/lib/swab/version.rb
@@ -1,3 +1,3 @@
 module Swab
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end


### PR DESCRIPTION
Amended the setting for the most recent. This will allow the most recent to be set alongside the date range for anything updated/added in the last 24hrs. I had previously assumed the date range would not work alongside this 